### PR TITLE
chore: update eslint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,12 +35,14 @@ export default [
     rules: {
       "react/no-unescaped-entities": "off",
       "react/prop-types": "off",
+      "no-console": "error",
     },
   },
 
   {
     files: ["**/*.ts", "**/*.tsx"],
     languageOptions: {
+      globals: { ...globals.browser, ...globals.node },
       parser: typescriptParser,
       parserOptions: {
         project: "./tsconfig.json",


### PR DESCRIPTION
globals.browser and globals.node were missing in the eslint config file for .ts and tsx files. There was regular errors for undefined values like console.log